### PR TITLE
Ia perbin

### DIFF
--- a/fastnc/__init__.py
+++ b/fastnc/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'Sunao Sugiyama, Rafael Heringer Gomes'
-__version__ = '1.1.23'
+__version__ = '1.1.24'
 __url__ = 'https://github.com/git-sunao/fastnc'
 # core modules:
 from . import fastnc

--- a/fastnc/__init__.py
+++ b/fastnc/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'Sunao Sugiyama, Rafael Heringer Gomes'
-__version__ = '1.1.22'
+__version__ = '1.1.23'
 __url__ = 'https://github.com/git-sunao/fastnc'
 # core modules:
 from . import fastnc

--- a/fastnc/bispectrum.py
+++ b/fastnc/bispectrum.py
@@ -401,7 +401,7 @@ class BispectrumBase:
         zs, pzs = self.zs_dict[name], self.pzs_dict[name]
         
         # model param
-        if params['perbin']:
+        if self.NLA_params['perbin']:
             AIA = self.NLA_params[f'AIA_{name}']
         else:
             AIA = self.NLA_params['AIA']


### PR DESCRIPTION
NLA model now accepts A_IA per bin. For the input of set_NLA_params, you specify alphaIA, z0, perbin=True, and AIA_{zbin} for each zbin. For example, if you have samples with names 1, 2, 3, and 4, then you need to specify the AIA_1, AIA_2, AIA_3, and AIA_4 in the inputs.

For parameter inference we would recommend to fix alphaIA to a fixed fiducial value, otherwise you increase the parameter space too much unnecessarily.